### PR TITLE
Fixed google font link base

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function getFontsStr(typography) {
 }
 
 function getFontsLink(str) {
-  const link = `<link href="${str}" rel="stylesheet" type="text/css" />`
+  const link = `<link href="//fonts.googleapis.com/css?family=${str}" rel="stylesheet" type="text/css" />`
   return link
 }
 


### PR DESCRIPTION
GoogleFont implementation includes the Google font URL base and I think this was lost when creating this repo. [See here](https://github.com/KyleAMathews/typography.js/blob/master/packages/react-typography/src/GoogleFont.js#L22)

For example, when I tried to use this I was ending up with just `Open+Sans:700|Merriweather:300,300i,700,700i`for the link, which was giving a console error since that isn't the correct full URL.

What it should be: `//fonts.googleapis.com/css?family=Open+Sans:700|Merriweather:300,300i,700,700i`

Thanks for making this by the way! Helpful for my React app